### PR TITLE
move date inside the function to make it work correctly

### DIFF
--- a/src/components/CreateTask.vue
+++ b/src/components/CreateTask.vue
@@ -8,10 +8,11 @@ const tasksStore = useTasksStore()
 const props = defineProps(['account'])
 const userId = props.account.data.session.user.id
 const taskTitle = ref('')
-const date = new Date()
-const formattedDate = date.toISOString().split('.')[0].replace('T', ' ')
 
 const _createTask = async () => {
+  const date = new Date()
+  const formattedDate = date.toISOString().split('.')[0].replace('T', ' ')
+
   const task = {
     title: taskTitle.value,
     inserted_at: formattedDate,


### PR DESCRIPTION
This PR fixes a bug where the timestamp of the task creation wasn't the real one, but the timestamp of the last time the page was refreshed.